### PR TITLE
Close bootstrap code block in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,3 +29,4 @@ This repository contains the Cursor agent configuration (`marvin.cursor.yaml`) a
 cd /Users/shaik/projects/marvin
 mkdir -p app src agent
 touch app/App.js
+```


### PR DESCRIPTION
## Summary
- close unclosed code block in README bootstrap instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6897709adb708321aedfc32f0e8409ae