### PR TITLE
Enforce 409 conflict on duplicate memory store

### DIFF
--- a/agent/api/store.py
+++ b/agent/api/store.py
@@ -12,6 +12,7 @@ from .models import StoreRequest, StoreResponse, ErrorResponse
 from .exceptions import MemoryServiceError, InvalidInputError, OpenAIServiceError, DatabaseError
 from openai import OpenAIError
 import sqlite3
+from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
 
@@ -94,9 +95,9 @@ async def store_memory_endpoint(
         
         # Return appropriate status code
         status_code = status.HTTP_409_CONFLICT if result.get("duplicate_detected") else status.HTTP_201_CREATED
-        
+
         response = StoreResponse(**result)
-        return response
+        return JSONResponse(status_code=status_code, content=response.model_dump())
         
     except InvalidInputError:
         raise

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -158,10 +158,9 @@ class TestDuplicateDetection:
         
         # Step 2: Store the exact same memory again
         second_store_response = client.post("/api/v1/store", json=store_payload)
-        
-        # The response might be 201 (created) or 409 (conflict) depending on implementation
-        # Both are acceptable for duplicate detection
-        assert second_store_response.status_code in [201, 409]
+
+        # A duplicate store should respond with a 409 Conflict
+        assert second_store_response.status_code == 409
         
         second_store_data = second_store_response.json()
         assert "duplicate_detected" in second_store_data


### PR DESCRIPTION
## Summary
- tighten duplicate memory test to require a 409 Conflict
- return proper status code from store endpoint using `JSONResponse`

## Testing
- `pytest tests/test_sanity.py::TestDuplicateDetection::test_duplicate_detection_on_second_store -q`
- `pytest tests/test_sanity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689770aa76988321a80c2049d6693a16