### PR TITLE
Improve memory decision and duplicate detection

### DIFF
--- a/agent/api/store.py
+++ b/agent/api/store.py
@@ -49,7 +49,7 @@ def get_settings() -> Settings:
     
     The system will:
     1. Generate an embedding for the input text using OpenAI
-    2. Check for duplicates using cosine similarity (threshold: 0.92)
+    2. Check for duplicates using cosine similarity (threshold: 0.97)
     3. Return duplicate information if found, or store the new memory
     
     Returns memory ID and duplicate detection results.

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Marvin is a semantic memory assistant with embedding-based storage, intelligent 
 ### Memory Operations
 - **Store Memories**: Natural language input with semantic embedding
 - **Query Memories**: Semantic search with similarity scoring
-- **Duplicate Detection**: Automatic detection with 85% similarity threshold
+- **Duplicate Detection**: Automatic detection with 97% similarity threshold
 - **Memory Management**: Update, delete, and retrieve specific memories
 
 ### Intelligent Clarification System

--- a/tests/e2e/test_e2e_live_openai.py
+++ b/tests/e2e/test_e2e_live_openai.py
@@ -163,7 +163,7 @@ def test_duplicate_detection_live():
         
         # Verify similarity score if present
         if "similarity_score" in second_data:
-            assert second_data["similarity_score"] >= 0.92, f"Expected similarity >= 0.92, got {second_data['similarity_score']}"
+            assert second_data["similarity_score"] >= 0.97, f"Expected similarity >= 0.97, got {second_data['similarity_score']}"
         
         # Verify memory_id matches original (should reference existing memory)
         assert "memory_id" in second_data

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -168,7 +168,7 @@ class TestDuplicateDetection:
         assert "existing_memory_preview" in second_store_data
         assert second_store_data["existing_memory_preview"] == "I lent a red pen to Alex."
         assert "similarity_score" in second_store_data
-        assert second_store_data["similarity_score"] >= 0.92  # Should be high similarity
+        assert second_store_data["similarity_score"] >= 0.97  # Should be high similarity
         
         # The memory_id should be the same as the original (existing memory)
         assert "memory_id" in second_store_data

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -95,7 +95,7 @@ class TestUpdateFlow:
         assert "existing_memory_preview" in duplicate_data
         assert "2580" in duplicate_data["existing_memory_preview"]
         assert "similarity_score" in duplicate_data
-        assert duplicate_data["similarity_score"] >= 0.92
+        assert duplicate_data["similarity_score"] >= 0.97
         assert "memory_id" in duplicate_data
         assert duplicate_data["memory_id"] == stored_memory_id
         


### PR DESCRIPTION
## Summary
- Add question-detection heuristic so statements store memories and questions trigger retrieval
- Reduce false duplicate matches by requiring exact text match and raising similarity threshold to 0.97
- Update documentation and tests for the new duplicate-detection behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4dd3c4fec83219fdbf6ceb0bb463e