### PR TITLE
Improve memory retrieval with natural-language answers

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -117,6 +117,13 @@ class Settings(BaseSettings):
         env="LLM_DECIDER_CONFIDENCE_MIN",
         description="Minimum confidence threshold for LLM decisions (below triggers clarification)"
     )
+    # LLM Answer Generation Configuration
+    llm_answer_model: str = Field(
+        default="gpt-4o-mini",
+        env="LLM_ANSWER_MODEL",
+        description="OpenAI model used to generate natural language answers from memories",
+    )
+
     
     class Config:
         env_file = ".env"

--- a/app/screens/ChatScreen.js
+++ b/app/screens/ChatScreen.js
@@ -51,12 +51,14 @@ export default function ChatScreen() {
 
       if (action === 'retrieve') {
         const candidates = (json?.result?.candidates || json?.candidates || []);
-        if (Array.isArray(candidates) && candidates.length > 0) {
+        if (json?.result?.answer) {
+          assistantText = json.result.answer;
+        } else if (Array.isArray(candidates) && candidates.length > 0) {
           assistantText = candidates[0]?.text || String(candidates[0]);
-          moreCount = Math.max(0, candidates.length - 1);
         } else {
           assistantText = 'No results';
         }
+        moreCount = Math.max(0, candidates.length - 1);
       } else if (action === 'store') {
         const savedText = json?.decision?.normalized_text || json?.result?.text || trimmed;
         assistantText = `Saved: ${savedText}`;


### PR DESCRIPTION
## Summary
- Synthesize answers from multiple memory candidates using an LLM
- Add `llm_answer_model` configuration for answer generation
- Front-end uses the synthesized answer instead of raw memory text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a625111f8883219fb59846d3db8683