### PR TITLE
Add min_score filtering for memory queries

### DIFF
--- a/agent/api/auto.py
+++ b/agent/api/auto.py
@@ -233,7 +233,8 @@ async def auto_endpoint(
             return JSONResponse(status_code=status_code, content=response.model_dump())
 
         if chosen_action == "retrieve":
-            candidates = query_memory(normalized_text)
+            # Use a higher top_k to allow multiple relevant memories to surface
+            candidates = query_memory(normalized_text, top_k=10)
             answer = _generate_answer(normalized_text, candidates, language, client, app_settings)
             response = AutoResponse(
                 action="retrieve",

--- a/agent/api/models.py
+++ b/agent/api/models.py
@@ -18,6 +18,12 @@ class QueryRequest(BaseModel):
     """Request model for querying memories."""
     query: str = Field(..., description="Search query text", min_length=1)
     top_k: int = Field(default=3, description="Number of top results to return", ge=1, le=100)
+    min_score: Optional[float] = Field(
+        default=None,
+        description="Minimum similarity score to include in results",
+        ge=0.0,
+        le=1.0,
+    )
 
 
 class UpdateRequest(BaseModel):

--- a/agent/api/query.py
+++ b/agent/api/query.py
@@ -114,7 +114,8 @@ async def query_memory_endpoint(
         "Query request received",
         extra={
             "query_length": len(request.query),
-            "top_k": request.top_k
+            "top_k": request.top_k,
+            "min_score": request.min_score,
         }
     )
     
@@ -125,9 +126,11 @@ async def query_memory_endpoint(
         
         if request.top_k <= 0 or request.top_k > 100:
             raise InvalidInputError("top_k must be between 1 and 100", field="top_k")
-        
+
         # Query memories
-        candidates = query_memory(request.query.strip(), request.top_k)
+        candidates = query_memory(
+            request.query.strip(), request.top_k, request.min_score
+        )
         
         # Convert to response models
         memory_candidates = [

--- a/tests/test_multi_match.py
+++ b/tests/test_multi_match.py
@@ -1,0 +1,16 @@
+def test_query_returns_multiple_matches(client):
+    """Store two related memories and ensure both are returned using min_score."""
+    first = {"text": "I left my blue shirt at home.", "language": "en"}
+    second = {"text": "I left my red shirt at the office.", "language": "en"}
+
+    # Store both memories
+    assert client.post("/api/v1/store", json=first).status_code == 201
+    assert client.post("/api/v1/store", json=second).status_code == 201
+
+    # Query with a min_score threshold to allow multiple matches
+    query_payload = {"query": "Where is my shirt?", "min_score": 0.5}
+    response = client.post("/api/v1/query", json=query_payload)
+    assert response.status_code == 200
+    data = response.json()
+    texts = [c["text"] for c in data["candidates"]]
+    assert first["text"] in texts and second["text"] in texts


### PR DESCRIPTION
## Summary
- allow query_memory to filter results by similarity with new optional `min_score`
- expose `min_score` in query API and increase retrieval breadth in auto endpoint
- add tests for multi-match scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6325e04608321bd450a9fe501cfff