### PR TITLE
feat: richer fallback responses

### DIFF
--- a/tests/test_generate_answer_fallback.py
+++ b/tests/test_generate_answer_fallback.py
@@ -1,0 +1,28 @@
+import pytest
+from agent.api.auto import _generate_answer
+
+
+class DummyClient:
+    class chat:
+        class completions:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise Exception("LLM unavailable")
+
+
+class DummySettings:
+    llm_answer_model = "gpt-test"
+
+
+def test_fallback_pronoun_conversion():
+    candidates = [{"text": "I lost my keys"}]
+    result = _generate_answer("Where are my keys?", candidates, "en", DummyClient(), DummySettings())
+    assert result == "I found the following information:\n1. You lost your keys"
+
+
+def test_fallback_multi_memory_aggregation():
+    candidates = [{"text": "I like my cat"}, {"text": "My dog likes me"}]
+    result = _generate_answer("Tell me about my pets", candidates, "en", DummyClient(), DummySettings())
+    assert result == (
+        "I found the following information:\n1. You like your cat\n2. Your dog likes you"
+    )


### PR DESCRIPTION
## Summary
- enumerate memory candidates in fallback answers and rewrite first-person pronouns to second person
- add deterministic template when LLM synthesis fails
- cover pronoun conversion and multi-memory aggregation in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a63262c3d88321807d76201bdd059a